### PR TITLE
Support `submitit` Hydra launcher, to launch runs on SLURM clusters

### DIFF
--- a/alliancecan-requirements.txt
+++ b/alliancecan-requirements.txt
@@ -26,6 +26,7 @@ pytorch-lightning~=1.7.0
 # Packages for which Compute Canada does not offer specially built wheels
 # (that must be installed from generic versions downloaded by pip)
 hydra-core~=1.2.0
+hydra-submitit-launcher
 python-dotenv
 StrEnum
 medpy

--- a/castor/config/experiment/camus/ar-vae.yaml
+++ b/castor/config/experiment/camus/ar-vae.yaml
@@ -3,7 +3,7 @@
 defaults:
   - camus/vae
   - /data/results_processors@_global_.results_processors:
-      - camus/latent_space_attributes_plot
+    - camus/latent_space_attributes_plot
   - override /task: ar-vae
 
 task:

--- a/castor/config/experiment/camus/deeplabv3.yaml
+++ b/castor/config/experiment/camus/deeplabv3.yaml
@@ -11,3 +11,5 @@ task:
   optim:
     lr: 1e-4
     weight_decay: 1e-4
+
+run_time_min: 1000

--- a/castor/config/experiment/camus/enet.yaml
+++ b/castor/config/experiment/camus/enet.yaml
@@ -11,3 +11,5 @@ task:
   optim:
     lr: 1e-3
     weight_decay: 1e-4
+
+run_time_min: 90

--- a/castor/config/experiment/camus/lunet.yaml
+++ b/castor/config/experiment/camus/lunet.yaml
@@ -16,3 +16,5 @@ task:
   optim:
     lr: 1e-4
     weight_decay: 0
+
+run_time_min: 250

--- a/castor/config/experiment/camus/unet.yaml
+++ b/castor/config/experiment/camus/unet.yaml
@@ -8,3 +8,5 @@ task:
   optim:
     lr: 1e-3
     weight_decay: 0
+
+run_time_min: 90

--- a/castor/config/experiment/camus/vae.yaml
+++ b/castor/config/experiment/camus/vae.yaml
@@ -21,3 +21,5 @@ task:
   optim:
     lr: 5e-4
     weight_decay: 1e-3
+
+run_time_min: 500


### PR DESCRIPTION
Depends on the [PR that introduces support for the `hydra-submitit-launcher` plugin in the `vital` submodule](https://github.com/vitalab/vital/pull/69).